### PR TITLE
Fix for "'HTML_Requester' object has no attribute 'extender_vars'".

### DIFF
--- a/snxconnect.py
+++ b/snxconnect.py
@@ -289,12 +289,12 @@ class HTML_Requester (object) :
             program via a socket.
         """
         for script in self.soup.find_all ('script') :
-            if '/* Extender.user_name' in script.text :
+            if script.string is not None and '/* Extender.user_name' in script.string:
                 break
         else :
             print ("Error retrieving extender variables")
             return
-        for line in script.text.split ('\n') :
+        for line in script.string.split ('\n') :
             if '/* Extender.user_name' in line :
                 break
         stmts = line.split (';')


### PR DESCRIPTION
Updates on BeautifuSoup4 library breaks the parse_extender when parsing /SNX/extender page, leading to "'HTML_Requester' object has no attribute 'extender_vars'" error. "text" attributes were replaced by "string".